### PR TITLE
create article routes and render sample object

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,24 @@
 const express = require('express')
+const path = require('path');
 
 // Init app
 const app = express();
+
+// Load View Engine
+app.set('views', path.join(__dirname, 'views'))
+app.set('view engine', 'pug')
 
 // Home Route
 app.get('/', function(req, res) {
   res.send('Hello world');
 });
+
+// Add Route
+app.get('/articles/add', function(req, res){
+  res.render('add_article', {
+    title: 'Add article'
+  });
+})
 
 // Start Server
 app.listen(3000, function() {

--- a/app.js
+++ b/app.js
@@ -10,7 +10,30 @@ app.set('view engine', 'pug')
 
 // Home Route
 app.get('/', function(req, res) {
-  res.send('Hello world');
+  let articles = [
+    {
+      id: 1,
+      title: 'Article One',
+      author: 'Denis',
+      body: 'This is article one'
+    },
+    {
+      id: 2,
+      title: 'Article Two',
+      author: 'Jacob',
+      body: 'This is article two'
+    },
+    {
+      id: 3,
+      title: 'Article Three',
+      author: 'Sam',
+      body: 'This is article three'
+    }
+  ]
+  res.render('index', {
+    title: 'Articles',
+    articles: articles
+  });
 });
 
 // Add Route

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "Knowledge Base app for Node JS",
   "main": "app.js",
   "scripts": {
-    "start": "node app"
+    "start": "nodemon app"
   },
   "author": "Denis Komarov",
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1",
     "pug": "^2.0.4"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.4"
   }
 }

--- a/views/add_article.pug
+++ b/views/add_article.pug
@@ -1,0 +1,4 @@
+extends layout
+
+block content
+    h1 #{title}

--- a/views/index.pug
+++ b/views/index.pug
@@ -1,0 +1,7 @@
+extends layout
+
+block content
+    h1 #{title}
+    ul
+      each article, i in articles
+        li #{article.title}

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -1,0 +1,10 @@
+doctype html
+html
+  head  
+    title Knowledgebase
+  body  
+    block content
+    br
+    hr
+    footer  
+      p Copyright &copy; 2020


### PR DESCRIPTION
currently there are two routes: index and /articles/add

article objects appear on index page